### PR TITLE
Script to launch everything

### DIFF
--- a/GSE/launchEverything.py
+++ b/GSE/launchEverything.py
@@ -6,11 +6,11 @@ import atexit
 
 def launchGUI():
     ## launch on different thread, return a Popen object to close later, pip output to stdout
-    return(subprocess.Popen([sys.executable, 'gui.py'], stdout=subprocess.PIPE))
+    return(subprocess.Popen([sys.executable, 'gui.py']))
 
 def launchServer():
     ## launch on different thread, return a Popen object to close later, pip output to stdout
-    return(subprocess.Popen([sys.executable, 'server.py'], stdout=subprocess.PIPE))
+    return(subprocess.Popen([sys.executable, 'server.py']))
 
 def launchSerialManager():
     print('List of Serial Devices Found:')
@@ -22,8 +22,8 @@ def launchSerialManager():
     bd = input('Blue Dawn Serial: ')
     um = input('Umbilical Serial: ')
 
-    ## launch on different thread, return Popen object to close later, pipe output to stdout
-    return(subprocess.Popen([sys.executable, 'serial_manager.py', bd, um], stdout=subprocess.PIPE))
+    ## launch on different thread, return Popen object to close later
+    return(subprocess.Popen([sys.executable, 'serial_manager.py', bd, um]))
 
 def exit(ts):
     for t in ts:

--- a/GSE/launchEverything.py
+++ b/GSE/launchEverything.py
@@ -12,25 +12,25 @@ def launchServer():
     ## launch on different thread, return a Popen object to close later, pip output to stdout
     return(subprocess.Popen([sys.executable, 'server.py']))
 
-def launchSerialManager():
-    print('List of Serial Devices Found:')
-    for x in list_serial_ports.comports():
+#def launchSerialManager():
+#    print('List of Serial Devices Found:')
+#    for x in list_serial_ports.comports():
         ## serial.tools.list_ports returns serialPort objects
         ## take the names of each first one
-        print(x[0])
-    print()
-    bd = input('Blue Dawn Serial: ')
-    um = input('Umbilical Serial: ')
+#        print(x[0])
+#    print()
+  #  bd = input('Blue Dawn Serial: ')
+  #  um = input('Umbilical Serial: ')
 
     ## launch on different thread, return Popen object to close later
-    return(subprocess.Popen([sys.executable, 'serial_manager.py', bd, um]))
+#    return(subprocess.Popen([sys.executable, 'serial_manager.py', bd, um]))
 
 def exit(ts):
     for t in ts:
         t.terminate()
 
 if __name__ == '__main__':
-    threads = [launchGUI(), launchServer(), launchSerialManager()]
+    threads = [launchGUI(), launchServer()]
     ## register exit to run before quit on threads
     atexit.register(exit, threads)
     while(True):

--- a/README.md
+++ b/README.md
@@ -1,17 +1,35 @@
-README.md
+Blue Dawn Ground Testing
+=========================  
+# Project Rapid
 
-Setup:
+## About:
 
-Upload the Arduino code (available in the Rapid Blue Dawn Flight library on github) to the Arduino. Do not open the Serial Monitor on the Arduino IDE!
+### Welcome to the Rapid's repository for our Ground Testing Software suite.
+The main item of interest is the GSE software. 
+Second is the code to be run on the Flight Computer in it's test configuration. 
+Also included is the code to be run on the custom umbilical cable which serves to measure the voltage and current draw of the Blue Dawn vehicle.
+We hav eincluded the nff-toolbox for ease of access and integration with our suite, though it is the property of Nanoracks LLC.
+Finally there are antiquated test scripts currently kept for no real reason.
 
-For Mac and Linux:
-- Locate the port at which the Arduino is connected to the computer. This can be found by looking under Tools/Ports in the Arduino IDE, or running "ls /dev/tty.usb*" in the Terminal
-- Run the simulator (nff-sim-nonwin.py) using Python3, i.e. "python3 nff-toolbox/nff-sim-nonwin.py"
+## Requirements
+This software is designed to be cross-platform compatible. 
+- It is built using `Python 3`, `PyQt5`, and `Arduino`.
+Python packages can be installed using `pip`. 
+- From the root project directory, run the command `pip install -r requirements.txt`. 
+We reccommend doing so in a python virtual environment in order to ensure stability.
 
-Currently unavailable for Windows, as the Curses module is only available for Mac and Linux
+If you do not have the Aruino IDE installed, do so now.
 
-For Windows, download an app that makes use of Windows Subsystem for Linux, then run from there.
-Notes on connecting to Arduino from WSL:
-- To make sure port is free, run `sudo chmod 666 /dev/ttyS[COM port #]`
-- Ensure correct baud rate: run `stty -F /dev/ttyS[COM port #] sane [Baud rate]`
-- Then simply run python script, and when prompted attempt to connect to `/dev/ttyS[COM port #]`
+## Setup
+### Flight Computer
+- Connect the Flight Computer to the Umbilical, ensure the umbilical is switched OFF. 
+- Connect both USB A cables (P2 and P3) from the Umbilical to your computer.
+- Open the Arduino IDE and note which port is being used by the the Umbilical's Nano and which by the Flight Computer's Uno. 
+- Upload `CurrentSenseUmbilical.ino` to the Umbilical's Nano (via P2).
+     - Check the Serial Monitor at 115200 to ensure telemetry is printing to the serial port.
+- Upload `Blue_Dawn_Test_Config.ino` to the Flight Computer (via P3).
+     - Check the Serial Monitor at 115200 to ensure telemetry is printing to the serial port.
+- Close the Serial Monitor.
+
+### GSE
+See `GSE/README.md`.


### PR DESCRIPTION
adds `launchEverything.py`, a python script that launches the serial manager, gui, and server in three separate processes and then does nothing. Shows list of all serial devices and asks where the arduinos are. terminates all three subprocesses before quitting.

note that this does not work with the gui - gui.py currently also tries to launch the serial manager.